### PR TITLE
Add Vitest tests for data joiners

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@emotion/react": "^11.11.4",
@@ -29,6 +30,7 @@
     "eslint-plugin-react": "^7.34.1",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.6",
-    "vite": "^6.2.1"
+    "vite": "^6.2.1",
+    "vitest": "^1.5.0"
   }
 }

--- a/src/services/__tests__/dataJoiners.test.js
+++ b/src/services/__tests__/dataJoiners.test.js
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { joinPharmClass, joinActiveIngredients, joinPackaging, joinRoutes, joinProductStatus } from '../dataJoiners.js';
+
+describe('dataJoiners helpers', () => {
+  it('joinPharmClass removes duplicates and joins with commas', () => {
+    const data = { pharm_class: ['classA', 'classB', 'classA'] };
+    const result = joinPharmClass(data);
+    expect(result).toBe('classA, classB');
+  });
+
+  it('joinActiveIngredients joins ingredient names', () => {
+    const data = { active_ingredients: [{ name: 'Ing1' }, { name: 'Ing2' }] };
+    const result = joinActiveIngredients(data);
+    expect(result).toBe('Ing1, Ing2');
+  });
+
+  it('joinPackaging joins packaging descriptions', () => {
+    const data = { packaging: [{ description: 'Pack1' }, { description: 'Pack2' }] };
+    const result = joinPackaging(data);
+    expect(result).toBe('Pack1, Pack2');
+  });
+
+  it('joinRoutes joins route strings', () => {
+    const data = { route: ['oral', 'topical'] };
+    const result = joinRoutes(data);
+    expect(result).toBe('oral, topical');
+  });
+
+  it('joinProductStatus returns correct status', () => {
+    expect(joinProductStatus({ finished: true })).toBe('Product finished');
+    expect(joinProductStatus({ finished: false })).toBe('Product in development');
+  });
+});


### PR DESCRIPTION
## Summary
- add Vitest dev dependency
- provide npm `test` script
- test helpers in `src/services/dataJoiners.js`

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68436bbd8c808329adaa74cdfe8912f3