### PR TITLE
Fix skeleton component name

### DIFF
--- a/src/components/Drug.jsx
+++ b/src/components/Drug.jsx
@@ -6,7 +6,7 @@ import { NavigateToHome } from './NavigateToHome';
 import { DrugInfoItem } from './DrugInfoItem';
 import "../assets/Drug.css";
 import { joinActiveIngredients, joinPackaging, joinPharmClass, joinProductStatus, joinRoutes } from '../services/dataJoiners';
-import { SqueletonDrugInfoItem } from './SqueletonDrugInfoItem';
+import { SkeletonDrugInfoItem } from './SkeletonDrugInfoItem';
 
 
 export function Drug() {
@@ -53,17 +53,17 @@ export function Drug() {
                     ><VaccinesIcon className="drug__icon" />Drug name</Typography>
 
                     <Box className="drug__info">
-                        <SqueletonDrugInfoItem label="Name:" />
-                        <SqueletonDrugInfoItem label="Medicine Code:" />
-                        <SqueletonDrugInfoItem label="Brand:" />
-                        <SqueletonDrugInfoItem label="Company:" />
-                        <SqueletonDrugInfoItem label="Active Ingredients:" />
-                        <SqueletonDrugInfoItem label="Product Status:" />
-                        <SqueletonDrugInfoItem label="Dosage forms:" />
-                        <SqueletonDrugInfoItem label="Routes for use:" />
-                        <SqueletonDrugInfoItem label="Product type:"/>
-                        <SqueletonDrugInfoItem label="Packaging:" />
-                        <SqueletonDrugInfoItem label="Pharmacological class:" />
+                        <SkeletonDrugInfoItem label="Name:" />
+                        <SkeletonDrugInfoItem label="Medicine Code:" />
+                        <SkeletonDrugInfoItem label="Brand:" />
+                        <SkeletonDrugInfoItem label="Company:" />
+                        <SkeletonDrugInfoItem label="Active Ingredients:" />
+                        <SkeletonDrugInfoItem label="Product Status:" />
+                        <SkeletonDrugInfoItem label="Dosage forms:" />
+                        <SkeletonDrugInfoItem label="Routes for use:" />
+                        <SkeletonDrugInfoItem label="Product type:"/>
+                        <SkeletonDrugInfoItem label="Packaging:" />
+                        <SkeletonDrugInfoItem label="Pharmacological class:" />
                     </Box>
                 </Box>}
 

--- a/src/components/SkeletonDrugInfoItem.jsx
+++ b/src/components/SkeletonDrugInfoItem.jsx
@@ -1,0 +1,9 @@
+import { Typography } from "@mui/material";
+
+export function SkeletonDrugInfoItem({ label }) {
+    return (
+       <Typography className='drug__info__data'>
+           <span className='drug__info__label'>{label}</span> ...
+       </Typography>
+    );
+}

--- a/src/components/SqueletonDrugInfoItem.jsx
+++ b/src/components/SqueletonDrugInfoItem.jsx
@@ -1,6 +1,0 @@
-import { Typography } from "@mui/material";
-export function SqueletonDrugInfoItem({label}) {
-    return (
-       <Typography className='drug__info__data'><span className='drug__info__label'>{label}</span> ...</Typography>
-    );
-}


### PR DESCRIPTION
## Summary
- rename `SqueletonDrugInfoItem.jsx` to `SkeletonDrugInfoItem.jsx`
- update component export name
- update imports and usage in `Drug.jsx`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68436e20ee588329953514078f010bf4